### PR TITLE
Use scutil --nc list instead of /usr/sbin/networksetup -listnetworkserviceorder

### DIFF
--- a/Vipinator/Services/VPNManager.swift
+++ b/Vipinator/Services/VPNManager.swift
@@ -23,8 +23,8 @@ enum VPNManager {
     private static let excludedServices = ["Wi-Fi", "Bluetooth PAN", "Thunderbolt Bridge"]
 
     static func getAvailableVPNs() async throws -> [VPNConnection] {
-        let output = try await runNetworkSetupCommand(arguments: ["-listnetworkserviceorder"])
-        return parseNetworkServices(output)
+        let output = try await runScutilCommand(arguments: ["--nc", "list"])
+        return parseVPNServices(output)
     }
 
     static func getStatus(for connection: VPNConnection) async throws -> VPNStatus {
@@ -48,9 +48,102 @@ enum VPNManager {
         return (initialStatus == .connected) && (finalStatus != .connected)
     }
 
+    static func extractDisplayName(from line: String) -> String {
+        let pattern = "\"([^\"]+)\""
+        if let range = line.range(of: pattern, options: .regularExpression) {
+            let match = String(line[range])
+            return match.replacingOccurrences(of: "\"", with: "")
+        }
+        return ""
+    }
+
+    static func extractConnectionStatus(from line: String) -> VPNStatus {
+        let pattern = "\\(([^)]+)\\)"
+        if let range = line.range(of: pattern, options: .regularExpression) {
+            let match = String(line[range])
+            let status = match.replacingOccurrences(of: "(", with: "").replacingOccurrences(
+                of: ")", with: "")
+            return parseStatusString(status)
+        }
+        return .disconnected
+    }
+
+    static func extractVPNType(from line: String) -> String {
+        let pattern = "\\[VPN:([^\\]]+)\\]"
+        if let range = line.range(of: pattern, options: .regularExpression) {
+            let match = String(line[range])
+            return match.replacingOccurrences(of: "[VPN:", with: "").replacingOccurrences(
+                of: "]", with: "")
+        }
+        return "VPN"
+    }
+
+    static func parseStatusString(_ status: String) -> VPNStatus {
+        let lowercased = status.lowercased()
+        switch lowercased {
+        case "connected":
+            return .connected
+        case "connecting":
+            return .connecting
+        case "disconnecting":
+            return .disconnecting
+        case "disconnected":
+            return .disconnected
+        default:
+            return .disconnected
+        }
+    }
+
+    static func parseVPNLine(_ line: String) -> VPNConnection? {
+        guard line.contains("[VPN:") else {
+            return nil
+        }
+
+        let displayName = extractDisplayName(from: line)
+        let status = extractConnectionStatus(from: line)
+        let vpnType = extractVPNType(from: line)
+
+        guard !displayName.isEmpty else {
+            return nil
+        }
+
+        var connection = VPNConnection(name: displayName, hardwarePort: vpnType, device: "")
+        connection.status = status
+        return connection
+    }
+
     private static func runNetworkSetupCommand(arguments: [String]) async throws -> String {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/sbin/networksetup")
+        process.arguments = arguments
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+
+        let output = String(decoding: outputData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        if !output.isEmpty {
+            return output
+        }
+
+        let errorOutput = String(decoding: errorData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        if !errorOutput.isEmpty {
+            throw VPNError.commandError(errorOutput)
+        }
+
+        throw VPNError.commandOutputDecodingFailed
+    }
+
+    private static func runScutilCommand(arguments: [String]) async throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/scutil")
         process.arguments = arguments
 
         let outputPipe = Pipe()
@@ -94,38 +187,19 @@ enum VPNManager {
         }
     }
 
-    private static func parseNetworkServices(_ output: String) -> [VPNConnection] {
+    private static func parseVPNServices(_ output: String) -> [VPNConnection] {
         let lines = output.components(separatedBy: .newlines)
         var vpnConnections: [VPNConnection] = []
-        var currentConnection = NetworkServiceInfo()
 
         for line in lines {
-            if line.matches(regex: "^\\(\\d+\\)") {
-                if let name = currentConnection.name,
-                   let hardwarePort = currentConnection.hardwarePort,
-                   !excludedServices.contains(name) {
-                    vpnConnections.append(
-                        VPNConnection(name: name, hardwarePort: hardwarePort, device: currentConnection.device ?? "")
-                    )
-                }
-                currentConnection.name = line.extractName()
-                currentConnection.hardwarePort = nil
-                currentConnection.device = nil
-            } else if line.contains("Hardware Port:") {
-                let components = line.components(separatedBy: ",")
-                if components.count >= 2 {
-                    currentConnection.hardwarePort = components[0].extractHardwarePort()
-                    currentConnection.device = components[1].extractDevice()
-                }
+            let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedLine.isEmpty || trimmedLine.contains("Available network connection services") {
+                continue
             }
-        }
 
-        if let name = currentConnection.name,
-           let hardwarePort = currentConnection.hardwarePort,
-           !excludedServices.contains(name) {
-            vpnConnections.append(
-                VPNConnection(name: name, hardwarePort: hardwarePort, device: currentConnection.device ?? "")
-            )
+            if let connection = parseVPNLine(trimmedLine) {
+                vpnConnections.append(connection)
+            }
         }
 
         return vpnConnections


### PR DESCRIPTION
### Switched from networksetup -listnetworkserviceorder to scutil --nc list for VPN detection

- **scutil --nc list** provides a direct and more reliable way to enumerate configured VPN connections, especially on recent macOS versions (available since ventura, mac os 13)
- **networksetup -listnetworkserviceorder** lists all network services (including non-VPN interfaces)

### Comparison of scutil and networksetup results:

**networksetup:**
![CleanShot 2025-05-26 at 12 48 59@2x](https://github.com/user-attachments/assets/349aaf37-4b76-4294-b9e5-555f7a5df0c8)

**scutil:**
![CleanShot 2025-05-26 at 12 49 06@2x](https://github.com/user-attachments/assets/1fdee181-03e3-4b90-92c4-df851ae1225f)


