### PR TITLE
Add reconnect-on-launch toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ timeline.xctimeline
 playground.xcworkspace
 
 .build/
+build/
 
 .DS_Store
-

--- a/Vipinator/Application/AppDelegate.swift
+++ b/Vipinator/Application/AppDelegate.swift
@@ -11,25 +11,64 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItemManager: VPNStatusItemManager!
     private var menuManager: VPNMenuManager!
     private var networkObserver: NetworkConfigurationObserver!
+    private var connectedVPNsBeforeSleep: [VPNConnection] = []
 
     func applicationDidFinishLaunching(_: Notification) {
         Task { @MainActor in
             statusItemManager = VPNStatusItemManager()
             menuManager = VPNMenuManager(statusItemManager: statusItemManager)
             networkObserver = NetworkConfigurationObserver(handler: handleNetworkConfigurationChange)
+            observeSleepWakeNotifications()
 
             await menuManager.loadVPNConnections()
             menuManager.rebuildMenu()
+            await VPNManager.connectLastUsedVPNOnLaunchIfNeeded()
             await menuManager.updateVPNStatuses()
         }
     }
 
     func applicationWillTerminate(_: Notification) {
         networkObserver.stopObserving()
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
     }
 
     private func handleNetworkConfigurationChange() {
         Task { @MainActor in
+            await menuManager.updateVPNStatuses()
+        }
+    }
+
+    private func observeSleepWakeNotifications() {
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(handleWillSleep),
+            name: NSWorkspace.willSleepNotification,
+            object: nil
+        )
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(handleDidWake),
+            name: NSWorkspace.didWakeNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleWillSleep() {
+        Task { @MainActor in
+            do {
+                connectedVPNsBeforeSleep = try await VPNManager.getConnectedVPNs()
+            } catch {
+                connectedVPNsBeforeSleep = []
+                print("Error checking connected VPNs before sleep: \(error)")
+            }
+        }
+    }
+
+    @objc private func handleDidWake() {
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(5))
+            await VPNManager.reconnectAfterWakeIfNeeded(connections: connectedVPNsBeforeSleep)
+            connectedVPNsBeforeSleep = []
             await menuManager.updateVPNStatuses()
         }
     }

--- a/Vipinator/Services/VPNManager.swift
+++ b/Vipinator/Services/VPNManager.swift
@@ -56,6 +56,10 @@ enum VPNManager {
         LastUsedVPN.name
     }
 
+    static func clearLastUsedVPN() {
+        LastUsedVPN.name = nil
+    }
+
     static func getAvailableVPNs() async throws -> [VPNConnection] {
         let output = try await runNetworkSetupCommand(arguments: ["-listnetworkserviceorder"])
         return parseNetworkServices(output)

--- a/Vipinator/Services/VPNManager.swift
+++ b/Vipinator/Services/VPNManager.swift
@@ -18,7 +18,44 @@ struct VPNConnection: Identifiable, Equatable {
     var status: VPNStatus = .disconnected
 }
 
+enum ReconnectAtStartup {
+    static let defaultsKey = "ReconnectAtStartup"
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: defaultsKey)
+    }
+}
+
+enum ReconnectAfterSleep {
+    static let defaultsKey = "ReconnectAfterSleep"
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: defaultsKey)
+    }
+}
+
+enum LastUsedVPN {
+    static let defaultsKey = "LastUsedVPNName"
+
+    static var name: String? {
+        get {
+            UserDefaults.standard.string(forKey: defaultsKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: defaultsKey)
+        }
+    }
+}
+
 enum VPNManager {
+    static func saveLastUsedVPN(_ name: String) {
+        LastUsedVPN.name = name
+    }
+
+    static func loadLastUsedVPN() -> String? {
+        LastUsedVPN.name
+    }
+
     static func getAvailableVPNs() async throws -> [VPNConnection] {
         let output = try await runNetworkSetupCommand(arguments: ["-listnetworkserviceorder"])
         return parseNetworkServices(output)
@@ -43,6 +80,56 @@ enum VPNManager {
         try await Task.sleep(for: .seconds(2))
         let finalStatus = try await getStatus(for: connection)
         return (initialStatus == .connected) && (finalStatus != .connected)
+    }
+
+    static func getConnectedVPNs() async throws -> [VPNConnection] {
+        var connectedVPNs: [VPNConnection] = []
+
+        for connection in try await getAvailableVPNs() {
+            let status = try await getStatus(for: connection)
+            if status == .connected {
+                connectedVPNs.append(connection)
+            }
+        }
+
+        return connectedVPNs
+    }
+
+    static func connectLastUsedVPNOnLaunchIfNeeded() async {
+        guard ReconnectAtStartup.isEnabled,
+              let vpnName = loadLastUsedVPN() else { return }
+
+        do {
+            let connections = try await getAvailableVPNs()
+            guard let connection = connections.first(where: { $0.name == vpnName }) else { return }
+            let status = try await getStatus(for: connection)
+
+            guard status == .disconnected else { return }
+            let success = try await connect(to: connection)
+            if !success {
+                print("Failed to reconnect VPN on launch: \(connection.name)")
+            }
+        } catch {
+            print("Error reconnecting VPN on launch: \(error)")
+        }
+    }
+
+    static func reconnectAfterWakeIfNeeded(connections: [VPNConnection]) async {
+        guard ReconnectAfterSleep.isEnabled else { return }
+
+        for connection in connections {
+            do {
+                let status = try await getStatus(for: connection)
+                guard status == .disconnected else { continue }
+
+                let success = try await connect(to: connection)
+                if !success {
+                    print("Failed to reconnect VPN after wake: \(connection.name)")
+                }
+            } catch {
+                print("Error reconnecting VPN after wake: \(connection.name). \(error)")
+            }
+        }
     }
 
     private static func runNetworkSetupCommand(arguments: [String], allowEmptyOutput: Bool = false) async throws -> String {

--- a/Vipinator/UI/GeneralSettingsView.swift
+++ b/Vipinator/UI/GeneralSettingsView.swift
@@ -10,11 +10,32 @@ import KeyboardShortcuts
 
 struct GeneralSettingsView: View {
     @State private var isOpenAtLogin: Bool = SMAppService.mainApp.status == .enabled
+    @AppStorage(ReconnectAtStartup.defaultsKey) private var reconnectAtStartup = false
+    @AppStorage(ReconnectAfterSleep.defaultsKey) private var reconnectAfterSleep = false
     
     var body: some View {
         Form {
-            Section(header: Text("Login Item"), footer: Text("Launch Vipinator in the menu bar when you start your device")) {
-                Toggle("Open at Login", isOn: $isOpenAtLogin.onChange(toggleOpenAtLogin))
+            Section(header: Text("Startup")) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Open at Login", isOn: $isOpenAtLogin.onChange(toggleOpenAtLogin))
+                    Text("Launch Vipinator in the menu bar when you start your device")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Reconnect at Startup", isOn: $reconnectAtStartup)
+                    Text("Reconnect to your most recently connected VPN when Vipinator launches")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Reconnect After Sleep", isOn: $reconnectAfterSleep)
+                    Text("Reconnect VPNs that were connected before sleep when your Mac wakes")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
             }
             
             Section(header: Text("Hotkeys"), footer: Text("Toggle the last VPN you connected to with a global keyboard shortcut")) {
@@ -38,4 +59,3 @@ struct GeneralSettingsView: View {
         }
     }
 }
-

--- a/Vipinator/UI/VPNMenuManager.swift
+++ b/Vipinator/UI/VPNMenuManager.swift
@@ -23,8 +23,6 @@ class VPNMenuManager: NSObject, NSMenuDelegate {
     private let quitMenuItem = NSMenuItem(title: "Quit",
                                           action: #selector(NSApplication.terminate(_:)),
                                           keyEquivalent: "q")
-    
-    private static let lastUsedVPNKey = "LastUsedVPNName"
 
     init(statusItemManager: VPNStatusItemManager) {
         self.statusItemManager = statusItemManager
@@ -135,7 +133,7 @@ class VPNMenuManager: NSObject, NSMenuDelegate {
         if vpnConnections.isEmpty {
             await loadVPNConnections()
         }
-        let name = loadLastUsedVPN() ?? ""
+        let name = VPNManager.loadLastUsedVPN() ?? ""
         guard
               let vpn = vpnConnections.first(where: { $0.name == name }) ?? vpnConnections.first else { return }
         await toggleVPN(vpn)
@@ -161,7 +159,7 @@ class VPNMenuManager: NSObject, NSMenuDelegate {
         do {
             let success = try await VPNManager.connect(to: vpn)
             if success {
-                saveLastUsedVPN(vpn.name)
+                VPNManager.saveLastUsedVPN(vpn.name)
             } else {
                 print("Failed to connect to VPN: \(vpn.name)")
             }
@@ -203,13 +201,5 @@ class VPNMenuManager: NSObject, NSMenuDelegate {
         }
 
         statusItemManager.updateStatus(isConnected: isAnyVPNConnected)
-    }
-    
-    private func saveLastUsedVPN(_ name: String) {
-        UserDefaults.standard.set(name, forKey: Self.lastUsedVPNKey)
-    }
-    
-    private func loadLastUsedVPN() -> String? {
-        UserDefaults.standard.string(forKey: Self.lastUsedVPNKey)
     }
 }

--- a/Vipinator/UI/VPNMenuManager.swift
+++ b/Vipinator/UI/VPNMenuManager.swift
@@ -172,7 +172,11 @@ class VPNMenuManager: NSObject, NSMenuDelegate {
     private func disconnectVPN(_ vpn: VPNConnection) async {
         do {
             let success = try await VPNManager.disconnect(from: vpn)
-            if !success { print("Failed to disconnect from VPN: \(vpn.name)") }
+            if success {
+                VPNManager.clearLastUsedVPN()
+            } else {
+                print("Failed to disconnect from VPN: \(vpn.name)")
+            }
             await updateVPNStatuses()
         } catch {
             print("Error disconnecting from VPN: \(vpn.name). \(error)")


### PR DESCRIPTION
## Summary

Adds a `Reconnect at Startup` toggle to the status menu.

When enabled, Vipinator remembers the current VPN and reconnects to it the next time the app launches.

## Changes

- Added `Reconnect at Startup` to the top of the status menu
- Added persistence for the reconnect setting and selected VPN
- Reconnects the saved VPN on launch when enabled
- Clears saved VPNs that no longer exist
- Updated the README with local build/run/install instructions
